### PR TITLE
do not require PhantomData to be imported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,11 +104,11 @@ pub fn require(args: TokenStream, input: TokenStream) -> TokenStream {
     // Generate PhantomData for the required number of states
     let phantom_data_count = remaining_args.len();
     let phantom_data: Vec<proc_macro2::TokenStream> = (0..phantom_data_count)
-        .map(|_| quote!(PhantomData))
+        .map(|_| quote!(::std::marker::PhantomData))
         .collect();
 
     let phantom_expr = if phantom_data.len() == 1 {
-        quote! { PhantomData }
+        quote! { ::std::marker::PhantomData }
     } else {
         quote! { ( #(#phantom_data),* ) }
     };
@@ -386,7 +386,7 @@ pub fn type_state(args: TokenStream, input: TokenStream) -> TokenStream {
     // the reason for using `fn() -> T` is to: https://github.com/ozgunozerk/state-shift/issues/1
     let phantom_fields = state_idents
         .iter()
-        .map(|ident| quote!(PhantomData<fn() -> #ident>))
+        .map(|ident| quote!(::std::marker::PhantomData<fn() -> #ident>))
         .collect::<Vec<_>>();
 
     let output = quote! {

--- a/tests/complex_example.rs
+++ b/tests/complex_example.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use state_shift::{require, states, switch_to, type_state};
 
 #[derive(Debug)]

--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use state_shift::{require, states, switch_to, type_state};
 
 #[derive(Debug)]
@@ -98,6 +96,8 @@ impl PlayerBuilder {
 // keep in mind that you need to provide the hidden `_state` field for your methods.
 impl PlayerBuilder {
     fn my_weird_method(&self) -> Self {
+        use std::marker::PhantomData;
+
         Self {
             race: Some(Race::Human),
             level: self.level,


### PR DESCRIPTION
<!-- Describe the changes introduced in this pull request. -->
The `state-shift` macros currently require the user to have `PhantomData` in scope. This qualifies the symbols in the macro so that it always uses `PhantomData` from `std` and cannot be confused by other symbols that the user may have renamed, for example.

<!-- Include any context necessary for understanding the PR's purpose. -->

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items below may not apply to your case (for example: fixing a typo). -->

- [x] Tests
- [x] Documentation

