### PR TITLE
visibility

### DIFF
--- a/src/require.rs
+++ b/src/require.rs
@@ -118,6 +118,7 @@ pub fn generate_impl_block_for_method_based_on_require_args(
     let fn_name = &input_fn.sig.ident;
     let fn_inputs = &input_fn.sig.inputs;
     let fn_output = &input_fn.sig.output;
+    let fn_vis = &input_fn.vis;
 
     // Generate the final output `impl` block.
     let output = quote! {
@@ -125,7 +126,7 @@ pub fn generate_impl_block_for_method_based_on_require_args(
         #merged_where_clause
         {
             #(#other_attrs)*
-            fn #fn_name(#fn_inputs) #fn_output {
+            #fn_vis fn #fn_name(#fn_inputs) #fn_output {
                 #(#new_fn_body)*
             }
         }

--- a/src/states.rs
+++ b/src/states.rs
@@ -70,7 +70,7 @@ pub fn states_inner(attr: TokenStream, item: TokenStream) -> TokenStream {
         let marker_name = Ident::new(&format!("{}", state), state.span());
 
         markers.push(quote! {
-            struct #marker_name;
+            pub struct #marker_name;
         });
 
         sealed_impls.push(quote! {

--- a/src/switch_to.rs
+++ b/src/switch_to.rs
@@ -15,6 +15,7 @@ pub fn switch_to_inner(args: TokenStream, input: TokenStream) -> TokenStream {
     let fn_name = &input_fn.sig.ident;
     let fn_inputs = &input_fn.sig.inputs;
     let fn_body = &input_fn.block;
+    let fn_vis = &input_fn.vis;
 
     // Get the full list of arguments as a vec: (A, B, State1, ...)
     let generic_idents: Vec<proc_macro2::TokenStream> =
@@ -54,7 +55,7 @@ pub fn switch_to_inner(args: TokenStream, input: TokenStream) -> TokenStream {
 
     // Construct the new method with the modified return type
     let output = quote! {
-        fn #fn_name(#fn_inputs) -> #modified_return_type {
+        #fn_vis fn #fn_name(#fn_inputs) -> #modified_return_type {
             #fn_body
         }
     };

--- a/src/type_state.rs
+++ b/src/type_state.rs
@@ -34,7 +34,8 @@ pub fn type_state_inner(args: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the input struct
     let input_struct = parse_macro_input!(input as ItemStruct);
     let struct_name = &input_struct.ident;
-    let generics = &input_struct.generics; // I added this line
+    let generics = &input_struct.generics;
+    let visibility = &input_struct.vis;
 
     // Extract fields from the struct
     let struct_fields = match input_struct.fields {
@@ -91,7 +92,7 @@ pub fn type_state_inner(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let output = quote! {
         #[allow(clippy::type_complexity)]
-        struct #struct_name<#combined_generics>
+        #visibility struct #struct_name<#combined_generics>
         #merged_where_clause
         {
             #struct_fields

--- a/tests/visibility_example.rs
+++ b/tests/visibility_example.rs
@@ -1,0 +1,93 @@
+mod example {
+    use std::marker::PhantomData;
+    use std::mem::MaybeUninit;
+
+    use state_shift::{states, switch_to, type_state};
+
+    pub struct MyParentObject<'base> {
+        #[allow(unused)]
+        inner: MaybeUninit<*mut core::ffi::c_void>,
+        _marker: PhantomData<&'base ()>,
+    }
+
+    impl<'base> MyParentObject<'base> {
+        pub fn new() -> Self {
+            MyParentObject {
+                inner: MaybeUninit::zeroed(),
+                _marker: PhantomData,
+            }
+        }
+
+        // ...
+
+        pub fn method(&'base self) -> MethodBuilder {
+            MethodBuilder::new()
+        }
+    }
+
+    pub struct Method {}
+
+    impl Method {
+        pub fn start(self) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    #[type_state(state_slots = 3, default_state = Unset)]
+    pub struct MethodBuilder {
+        #[allow(unused)]
+        slot_a: Option<u8>,
+        slot_b: Option<u8>,
+    }
+
+    impl MethodBuilder {}
+
+    #[states(Unset, ASet, BSet, AOrBSet)]
+    impl MethodBuilder {
+        #[require(Unset, Unset, Unset)] // require the default state for the constructor
+        pub fn new() -> MethodBuilder {
+            MethodBuilder {
+                slot_a: None,
+                slot_b: None,
+            }
+        }
+
+        #[require(Unset, B, C)]
+        #[switch_to(ASet, B, AOrBSet)]
+        pub fn set_slot_a(self, slot_a: u8) -> MethodBuilder {
+            MethodBuilder {
+                slot_a: Some(slot_a),
+                slot_b: self.slot_b,
+            }
+        }
+
+        #[require(A, BSet, C)]
+        #[switch_to(A, BSet, AOrBSet)]
+        pub fn set_slot_b(self, slot_b: u8) -> MethodBuilder {
+            MethodBuilder {
+                slot_a: self.slot_a,
+                slot_b: Some(slot_b),
+            }
+        }
+
+        #[require(A, B, AOrBSet)]
+        pub fn build(self) -> Method {
+            Method {}
+        }
+
+        #[require(A, B, AOrBSet)]
+        pub fn start(self) -> Result<(), String> {
+            Ok(())
+        }
+    }
+}
+
+#[test]
+fn test_method_builder() {
+    let myparentobj = example::MyParentObject::new();
+
+    // using the clean builder pattern within the parent
+    let meth = myparentobj.method().set_slot_a(42).build();
+    let res = meth.start();
+    assert!(res.is_ok())
+}


### PR DESCRIPTION
Fixes #9 

Basically: 
- retains the visibility of the impl methods
- retains the visibility of the struct
- all the marker structs generated for the state representations are `pub` by default. If there is an argument for opting out of this default, it can be discussed in its own issue