### PR TITLE
Update imports to remove all std to core

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Say, you want to build a player, and some fields need to be set before the other
 > A simple Type-State `PlayerBuilder` example WITHOUT state-shift:
 
 ```rust
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 struct PlayerBuilder<State1 = Initial> {
     race: Option<Race>,
@@ -639,7 +639,7 @@ And you know how Rust compiler is. It is very strict about types!
 >             race: Some(Race::Human),
 >             level: self.level,
 >             skill_slots: self.skill_slots,
->            _state: (::std::marker::PhantomData), // Don't forget this!
+>            _state: (::core::marker::PhantomData), // Don't forget this!
 >         }
 >     }
 > }

--- a/examples/complex_expanded.rs
+++ b/examples/complex_expanded.rs
@@ -3,7 +3,7 @@
 /// and does not expand irrelevant parts of the code (e.g. `#[derive(Debug)]`, etc.)
 ///
 /// This file serves the purpose of revealing what's happening behind the curtains.
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 #[derive(Debug)]
 struct Player {

--- a/examples/lifetime_example.rs
+++ b/examples/lifetime_example.rs
@@ -3,7 +3,7 @@
 /// and does not expand irrelevant parts of the code (e.g. `#[derive(Debug)]`, etc.)
 ///
 /// This file serves the purpose of revealing what's happening behind the curtains.
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 #[derive(Debug)]
 struct Player<'a, T> {

--- a/examples/simple_expanded.rs
+++ b/examples/simple_expanded.rs
@@ -3,7 +3,7 @@
 /// and does not expand irrelevant parts of the code (e.g. `#[derive(Debug)]`, etc.)
 ///
 /// This file serves the purpose of revealing what's happening behind the curtains.
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 #[derive(Debug)]
 struct Player {

--- a/src/require.rs
+++ b/src/require.rs
@@ -64,11 +64,11 @@ pub fn generate_impl_block_for_method_based_on_require_args(
 
     // Generate PhantomData for the required number of states
     let phantom_data: Vec<_> = (0..parsed_args.len())
-        .map(|_| quote!(::std::marker::PhantomData))
+        .map(|_| quote!(::core::marker::PhantomData))
         .collect();
 
     let phantom_expr = if phantom_data.len() == 1 {
-        quote! { ::std::marker::PhantomData }
+        quote! { ::core::marker::PhantomData }
     } else {
         quote! { ( #(#phantom_data),* ) }
     };

--- a/src/type_state.rs
+++ b/src/type_state.rs
@@ -121,7 +121,7 @@ pub fn type_state_inner(args: TokenStream, input: TokenStream) -> TokenStream {
     // the reason for using `fn() -> T` is to: https://github.com/ozgunozerk/state-shift/issues/1
     let phantom_fields = state_idents
         .iter()
-        .map(|ident| quote!(::std::marker::PhantomData<fn() -> #ident>))
+        .map(|ident| quote!(::core::marker::PhantomData<fn() -> #ident>))
         .collect::<Vec<_>>();
 
     // Generate the final output

--- a/tests/lifetime_example.rs
+++ b/tests/lifetime_example.rs
@@ -1,6 +1,6 @@
 use state_shift::{impl_state, type_state};
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 #[derive(Debug)]
 struct Player<'a, T> {
@@ -125,7 +125,7 @@ where
     T: Debug,
 {
     fn my_weird_method(&self) -> Self {
-        use std::marker::PhantomData;
+        use core::marker::PhantomData;
 
         Self {
             race: Some(Race::Human),

--- a/tests/simple_example.rs
+++ b/tests/simple_example.rs
@@ -96,7 +96,7 @@ impl PlayerBuilder {
 // keep in mind that you need to provide the hidden `_state` field for your methods.
 impl PlayerBuilder {
     fn my_weird_method(&self) -> Self {
-        use std::marker::PhantomData;
+        use core::marker::PhantomData;
 
         Self {
             race: Some(Race::Human),

--- a/tests/visibility_example.rs
+++ b/tests/visibility_example.rs
@@ -1,6 +1,6 @@
 mod example {
-    use std::marker::PhantomData;
-    use std::mem::MaybeUninit;
+    use core::marker::PhantomData;
+    use core::mem::MaybeUninit;
 
     use state_shift::{impl_state, type_state};
 


### PR DESCRIPTION
Replaced instances of std::marker::PhantomData and std::mem::MaybeUninit with their core equivalents. This change affects various source files and examples to ensure consistency and potentially reduce dependency overhead.

This will allow no-std crates to use this crate

Fixes #24 

Replaces all instances of std imports with core imports

#### PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Pallets, that require benchmarks, are added to `scripts/assets/pallets.txt` (Pallet require benchmark if it has WeightInfo config type)
